### PR TITLE
feat: support to find a configuration file recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For `plan` command, you also need to specify `plan` as the argument of tfnotify.
 
 ### Configurations
 
-When running tfnotify, you can specify the configuration path via `--config` option (if it's omitted, it defaults to `{.,}tfnotify.y{,a}ml`).
+When running tfnotify, you can specify the configuration path via `--config` option (if it's omitted, the configuration file `{.,}tfnotify.y{,a}ml` is searched from the current directory to the root directory).
 
 The example settings of GitHub and GitHub Enterprise, Slack, [Typetalk](https://www.typetalk.com/) are as follows. Incidentally, there is no need to replace TOKEN string such as `$GITHUB_TOKEN` with the actual token. Instead, it must be defined as environment variables in CI settings.
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/suzuki-shunsuke/go-findconfig/findconfig"
 	"gopkg.in/yaml.v2"
 )
 
@@ -227,22 +228,18 @@ func (cfg *Config) GetNotifierType() string {
 
 // Find returns config path
 func (cfg *Config) Find(file string) (string, error) {
-	var files []string
-	if file == "" {
-		files = []string{
-			"tfnotify.yaml",
-			"tfnotify.yml",
-			".tfnotify.yaml",
-			".tfnotify.yml",
-		}
-	} else {
-		files = []string{file}
-	}
-	for _, file := range files {
-		_, err := os.Stat(file)
-		if err == nil {
+	if file != "" {
+		if _, err := os.Stat(file); err == nil {
 			return file, nil
 		}
+		return "", errors.New("config for tfnotify is not found at all")
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get a current directory path: %w", err)
+	}
+	if p := findconfig.Find(wd, findconfig.Exist, "tfnotify.yaml", "tfnotify.yml", ".tfnotify.yaml", ".tfnotify.yml"); p != "" {
+		return p, nil
 	}
 	return "", errors.New("config for tfnotify is not found at all")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -440,6 +441,10 @@ func removeDummy(file string) {
 }
 
 func TestFind(t *testing.T) { //nolint:paralleltest
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
 	testCases := []struct {
 		file   string
 		expect string
@@ -478,7 +483,7 @@ func TestFind(t *testing.T) { //nolint:paralleltest
 		{
 			// in case of no args passed
 			file:   "",
-			expect: "tfnotify.yaml",
+			expect: filepath.Join(wd, "tfnotify.yaml"),
 			ok:     true,
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -483,15 +483,18 @@ func TestFind(t *testing.T) { //nolint:paralleltest
 		},
 	}
 	var cfg Config
-	for _, testCase := range testCases {
-		createDummy(testCase.file)
+	for _, testCase := range testCases { //nolint:paralleltest
+		testCase := testCase
+		t.Run(testCase.file, func(t *testing.T) {
+			createDummy(testCase.file)
+			actual, err := cfg.Find(testCase.file)
+			if (err == nil) != testCase.ok {
+				t.Errorf("got error %q", err)
+			}
+			if actual != testCase.expect {
+				t.Errorf("got %q but want %q", actual, testCase.expect)
+			}
+		})
 		defer removeDummy(testCase.file)
-		actual, err := cfg.Find(testCase.file)
-		if (err == nil) != testCase.ok {
-			t.Errorf("got error %q", err)
-		}
-		if actual != testCase.expect {
-			t.Errorf("got %q but want %q", actual, testCase.expect)
-		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/nulab/go-typetalk v2.1.1+incompatible
+	github.com/suzuki-shunsuke/go-findconfig v1.0.0
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/xanzy/go-gitlab v0.22.3
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/suzuki-shunsuke/go-findconfig v1.0.0 h1:RSETNCdYurpepqz/z9iM8DzJKK6TbvtV63ZVCIXaxkI=
+github.com/suzuki-shunsuke/go-findconfig v1.0.0/go.mod h1:u/0Zz6/GDE6G0gofzVhR9UPOIKLSUoDMjUoFWqOoVlg=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/xanzy/go-gitlab v0.22.3 h1:/rNlZ2hquUWNc6rJdntVM03tEOoTmnZ1lcNyJCl0WlU=
@@ -80,4 +82,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
## AS IS

the configuration path defaults to `{.,}tfnotify.y{,a}ml`.

## TO BE

the configuration file `{.,}tfnotify.y{,a}ml` is searched recursively from the current directory to the root directory.