### PR TITLE
feat: complement ci and GitHub Repository owner and name from CI builtin environment variables

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -50,6 +50,32 @@ $ tfnotify version
 tfnotify version 1.3.3
 ```
 
+### complement CI and GitHub Repository owner and name from environment variables
+
+The configuration of CI and GitHub Repository owner and name is complemented by CI builtin environment variables.
+[suzuki-shunsuke/go-ci-env](https://github.com/suzuki-shunsuke/go-ci-env) is used to complement them.
+So currently, this feature doesn't support Google CloudBuild for now.
+
+AS IS
+
+```yaml
+ci: circleci
+notifier:
+  github:
+    token: $GITHUB_TOKEN
+    repository:
+      owner: suzuki-shunsuke
+      name: tfcmt
+```
+
+We can omit `ci` and `repository`.
+
+```yaml
+notifier:
+  github:
+    token: $GITHUB_TOKEN
+```
+
 ## Others
 
 * refactoring

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/nulab/go-typetalk v2.1.1+incompatible
+	github.com/suzuki-shunsuke/go-ci-env v1.1.0
 	github.com/suzuki-shunsuke/go-findconfig v1.0.0
 	github.com/urfave/cli/v2 v2.3.0
 	github.com/xanzy/go-gitlab v0.22.3

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/suzuki-shunsuke/go-ci-env v1.1.0 h1:eGpItM2bEDtHFXYYEm8zz+kDGxWlhOtwNK58cREa1QU=
+github.com/suzuki-shunsuke/go-ci-env v1.1.0/go.mod h1:kO9UgcQIAH4Pu4ESkUJHPuQEtesxHPKkpQqeJHJzzdk=
 github.com/suzuki-shunsuke/go-findconfig v1.0.0 h1:RSETNCdYurpepqz/z9iM8DzJKK6TbvtV63ZVCIXaxkI=
 github.com/suzuki-shunsuke/go-findconfig v1.0.0/go.mod h1:u/0Zz6/GDE6G0gofzVhR9UPOIKLSUoDMjUoFWqOoVlg=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=

--- a/main.go
+++ b/main.go
@@ -339,6 +339,7 @@ func newConfig(ctx *cli.Context) (config.Config, error) {
 		return cfg, err
 	}
 	cfg.Vars = vm
+	cfg.Complement()
 	if err := cfg.Validation(); err != nil {
 		return cfg, err
 	}


### PR DESCRIPTION
The configuration of CI and GitHub Repository owner and name is complemented by CI builtin environment variables.
[suzuki-shunsuke/go-ci-env](https://github.com/suzuki-shunsuke/go-ci-env) is used to complement them.
So currently, this feature doesn't support Google CloudBuild for now.

AS IS

```yaml
ci: circleci
notifier:
  github:
    token: $GITHUB_TOKEN
    repository:
      owner: suzuki-shunsuke
      name: tfcmt
```

We can omit `ci` and `notifier.github.repository`.

```yaml
notifier:
  github:
    token: $GITHUB_TOKEN
```