### PR TITLE
feat: support the configuration keep_duplicate_comments

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -8,6 +8,7 @@
 * support to pass variables by -var option
 * support to find the configuration file recursively
 * support --version option and version command
+* support `keep_duplicate_comments` to keep duplicate comments
 
 ### don't recreate labels
 
@@ -82,6 +83,19 @@ We can omit `ci` and `repository`.
 notifier:
   github:
     token: $GITHUB_TOKEN
+```
+
+### support `keep_duplicate_comments` to keep duplicate comments
+
+tfnotify deletes duplicated comments at GitHub and GitLab.
+But by setting `keep_duplicate_comments: true`, tfnotify doesn't remove them.
+
+```yaml
+notifier:
+  github:
+    token: $GITHUB_TOKEN
+keep_duplicate_comments: true
+# ...
 ```
 
 ## Others

--- a/config/config.go
+++ b/config/config.go
@@ -14,10 +14,11 @@ import (
 
 // Config is for tfnotify config structure
 type Config struct {
-	CI        string            `yaml:"ci"`
-	Notifier  Notifier          `yaml:"notifier"`
-	Terraform Terraform         `yaml:"terraform"`
-	Vars      map[string]string `yaml:"-"`
+	CI                    string            `yaml:"ci"`
+	Notifier              Notifier          `yaml:"notifier"`
+	Terraform             Terraform         `yaml:"terraform"`
+	Vars                  map[string]string `yaml:"-"`
+	KeepDuplicateComments bool              `yaml:"keep_duplicate_comments"`
 
 	path string
 }

--- a/main.go
+++ b/main.go
@@ -139,6 +139,7 @@ func (t *tfnotify) getNotifier(ctx context.Context, ci CI, selectedNotifier stri
 			WarnDestroy:            t.warnDestroy,
 			ResultLabels:           labels,
 			Vars:                   t.config.Vars,
+			KeepDuplicateComments:  t.config.KeepDuplicateComments,
 		})
 		if err != nil {
 			return nil, err
@@ -156,10 +157,11 @@ func (t *tfnotify) getNotifier(ctx context.Context, ci CI, selectedNotifier stri
 				Title:    t.context.String("title"),
 				Message:  t.context.String("message"),
 			},
-			CI:       ci.URL,
-			Parser:   t.parser,
-			Template: t.template,
-			Vars:     t.config.Vars,
+			CI:                    ci.URL,
+			Parser:                t.parser,
+			Template:              t.template,
+			Vars:                  t.config.Vars,
+			KeepDuplicateComments: t.config.KeepDuplicateComments,
 		})
 		if err != nil {
 			return nil, err

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -35,15 +35,16 @@ type Client struct {
 
 // Config is a configuration for GitHub client
 type Config struct {
-	Token        string
-	BaseURL      string
-	Owner        string
-	Repo         string
-	PR           PullRequest
-	CI           string
-	Parser       terraform.Parser
-	UseRawOutput bool
-	WarnDestroy  bool
+	Token                 string
+	BaseURL               string
+	Owner                 string
+	Repo                  string
+	PR                    PullRequest
+	CI                    string
+	Parser                terraform.Parser
+	UseRawOutput          bool
+	WarnDestroy           bool
+	KeepDuplicateComments bool
 	// Template is used for all Terraform command output
 	Template terraform.Template
 	// DestroyWarningTemplate is used only for additional warning

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -106,7 +106,9 @@ func (g *NotifyService) Notify(ctx context.Context, body string) (exit int, err 
 	value := template.GetValue()
 
 	if cfg.PR.IsNumber() {
-		g.client.Comment.DeleteDuplicates(ctx, value.Title)
+		if !cfg.KeepDuplicateComments {
+			g.client.Comment.DeleteDuplicates(ctx, value.Title)
+		}
 	}
 
 	_, isApply := parser.(*terraform.ApplyParser)

--- a/notifier/gitlab/client.go
+++ b/notifier/gitlab/client.go
@@ -33,15 +33,16 @@ type Client struct {
 
 // Config is a configuration for GitHub client
 type Config struct {
-	Token     string
-	BaseURL   string
-	NameSpace string
-	Project   string
-	MR        MergeRequest
-	CI        string
-	Parser    terraform.Parser
-	Template  terraform.Template
-	Vars      map[string]string
+	Token                 string
+	BaseURL               string
+	NameSpace             string
+	Project               string
+	MR                    MergeRequest
+	CI                    string
+	Parser                terraform.Parser
+	Template              terraform.Template
+	Vars                  map[string]string
+	KeepDuplicateComments bool
 }
 
 // MergeRequest represents GitLab Merge Request metadata

--- a/notifier/gitlab/notify.go
+++ b/notifier/gitlab/notify.go
@@ -40,7 +40,9 @@ func (g *NotifyService) Notify(ctx context.Context, body string) (exit int, err 
 	value := template.GetValue()
 
 	if cfg.MR.IsNumber() {
-		g.client.Comment.DeleteDuplicates(value.Title)
+		if !cfg.KeepDuplicateComments {
+			g.client.Comment.DeleteDuplicates(value.Title)
+		}
 	}
 
 	_, isApply := parser.(*terraform.ApplyParser)


### PR DESCRIPTION
tfnotify deletes duplicated comments at GitHub and GitLab.
In this pull request the configuration option `keep_duplicate_comments` is added.
But by setting `keep_duplicate_comments: true`, tfnotify doesn't remove them.

```yaml
notifier:
  github:
    token: $GITHUB_TOKEN
keep_duplicate_comments: true
# ...
```